### PR TITLE
Updated provenance of model 6016 vs 6012.

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,4 @@
-EPICS driver for Health Physics Instruments (HPI) 6016 Area Radiation Monitor
+EPICS driver for Health Physics Instruments (HPI) 6012 family of Area Radiation Monitor
+This driver was developed for an HPI produced variation for Brookhaven, named 6016.
 
 Includes simulator (hpisim3.py) with fault injection options for testing.


### PR DESCRIPTION
Note about 6012 and 6016 history.